### PR TITLE
fix: GenRndCPUKey endless loop bug

### DIFF
--- a/src/x360Utils/CPUKey/CpukeyUtils.cs
+++ b/src/x360Utils/CPUKey/CpukeyUtils.cs
@@ -14,14 +14,10 @@
                 _random.NextBytes(key);
                 if(BitOperations.DataIsZero(ref key, 0, key.Length))
                     UpdateRandom((int)(DateTime.Now.Ticks & 0xFFFF));
-                try {
-                    VerifyCPUKeyHammingWeight(ref key);
-                    CalculateCPUKeyECD(ref key);
-                    return key;
-                }
-                catch(X360UtilsException) {}
             }
-            while(true);
+            while(!TryVerifyCPUKeyHammingWeight(ref key));
+            CalculateCPUKeyECD(ref key);
+            return key;
         }
 
         private static void CalculateCPUKeyECD(ref byte[] key) {

--- a/src/x360Utils/CPUKey/CpukeyUtils.cs
+++ b/src/x360Utils/CPUKey/CpukeyUtils.cs
@@ -53,7 +53,7 @@
                 throw new X360UtilsException(X360UtilsException.X360UtilsErrors.InvalidKeyECD);
         }
 
-        private static void VerifyCPUKeyHammingWeight(ref byte[] key) {
+        private static void VerifyCPUKeyHammingWeight(ref byte[] cpukey) {
             UInt64 part0 = BitOperations.Swap(BitConverter.ToUInt64(cpukey, 0));
             UInt64 part1 = BitOperations.Swap(BitConverter.ToUInt64(cpukey, 8));
             if(BitOperations.CountSetBits(part0) + BitOperations.CountSetBits(part1 & 0xFFFFFFFFFF030000) != 53)
@@ -77,9 +77,9 @@
 
         public static void VerifyCpuKey(UInt64 part0, UInt64 part1) {
             var key = new byte[0x10];
-            var tmp = BitConverter.GetBytes(BitOperations.Swap(part0));
+            var tmp = BitConverter.GetBytes(part0);
             Buffer.BlockCopy(tmp, 0, key, 0, tmp.Length);
-            tmp = BitConverter.GetBytes(BitOperations.Swap(part1));
+            tmp = BitConverter.GetBytes(part1);
             Buffer.BlockCopy(tmp, 0, key, tmp.Length, tmp.Length);
             VerifyCPUKeyHammingWeight(ref key);
             VerifyCPUKeyECD(ref key);

--- a/src/x360Utils/CPUKey/CpukeyUtils.cs
+++ b/src/x360Utils/CPUKey/CpukeyUtils.cs
@@ -43,6 +43,8 @@
 
 		private static bool TryVerifyCPUKeyECD(ref byte[] cpukey)
 		{
+			if (cpukey is null || cpukey.Length != 0x10)
+				return false;
             var scratch = new byte[0x10];
             Buffer.BlockCopy(cpukey, 0, scratch, 0, cpukey.Length);
             CalculateCPUKeyECD(ref scratch);
@@ -50,12 +52,16 @@
 		}
 
 		private static void VerifyCPUKeyECD(ref byte[] cpukey) {
+			if (cpukey is null)
+				throw new ArgumentNullException(nameof(cpukey));
 			if (!TryVerifyCPUKeyECD(ref cpukey))
                 throw new X360UtilsException(X360UtilsException.X360UtilsErrors.InvalidKeyECD);
         }
 
 		private static bool TryVerifyCPUKeyHammingWeight(ref byte[] cpukey)
 		{
+			if (cpukey is null || cpukey.Length != 0x10)
+				return false;
 			return TryVerifyCPUKeyHammingWeight(BitOperations.Swap(BitConverter.ToUInt64(cpukey, 0)), BitOperations.Swap(BitConverter.ToUInt64(cpukey, 8)));
 		}
 
@@ -65,6 +71,8 @@
 		}
 
 		private static void VerifyCPUKeyHammingWeight(ref byte[] cpukey) {
+			if (cpukey is null)
+				throw new ArgumentNullException(nameof(cpukey));
 			if (!TryVerifyCPUKeyHammingWeight(BitOperations.Swap(BitConverter.ToUInt64(cpukey, 0)), BitOperations.Swap(BitConverter.ToUInt64(cpukey, 8))))
 				throw new X360UtilsException(X360UtilsException.X360UtilsErrors.InvalidKeyHamming);
 		}
@@ -81,6 +89,13 @@
 		/// <returns>true if the CPUKey is valid, otherwise false</returns>
 		public static bool TryVerifyCPUKey(string cpukey)
 		{
+			if (cpukey is null)
+				return false;
+
+			cpukey = cpukey.Trim();
+			if (String.IsNullOrEmpty(cpukey))
+				return false;
+
 			var tmp = StringUtils.HexToArray(cpukey.Trim());
 			return TryVerifyCPUKey(ref tmp);
 		}
@@ -91,7 +106,7 @@
 		/// <returns>true if the CPUKey is valid, otherwise false</returns>
 		public static bool TryVerifyCPUKey(ref byte[] cpukey)
 		{
-			if (cpukey.Length != 0x10)
+			if (cpukey is null || cpukey.Length != 0x10)
 				return false;
 			return (TryVerifyCPUKeyHammingWeight(ref cpukey) && TryVerifyCPUKeyECD(ref cpukey));
 		}
@@ -120,8 +135,14 @@
 		/// <param name="cpukey"></param>
 		/// <exception cref="X360UtilsException">Throws if CPUKey is wrong length (0x20 chars), or invalid hamming/ECD</exception>
 		public static void VerifyCpuKey(string cpukey) {
-            cpukey = cpukey.Trim();
-            var tmp = StringUtils.HexToArray(cpukey);
+			if (cpukey is null)
+				throw new ArgumentNullException(nameof(cpukey));
+
+			cpukey = cpukey.Trim();
+			if (String.IsNullOrEmpty(cpukey))
+				throw new X360UtilsException(X360UtilsException.X360UtilsErrors.TooShortKey);
+
+			var tmp = StringUtils.HexToArray(cpukey);
             VerifyCpuKey(ref tmp);
         }
 
@@ -131,7 +152,9 @@
 		/// </summary>
 		/// <exception cref="X360UtilsException">Throws if CPUKey is wrong length (0x10 bytes), or invalid hamming/ECD</exception>
 		public static void VerifyCpuKey(ref byte[] cpukey) {
-            if(cpukey.Length < 0x10)
+			if (cpukey is null)
+				throw new ArgumentNullException(nameof(cpukey));
+			if (cpukey.Length < 0x10)
                 throw new X360UtilsException(X360UtilsException.X360UtilsErrors.TooShortKey);
             if(cpukey.Length > 0x10)
                 throw new X360UtilsException(X360UtilsException.X360UtilsErrors.TooLongKey);

--- a/src/x360Utils/CPUKey/CpukeyUtils.cs
+++ b/src/x360Utils/CPUKey/CpukeyUtils.cs
@@ -54,13 +54,16 @@
         }
 
         private static void VerifyCPUKeyHammingWeight(ref byte[] cpukey) {
-            UInt64 part0 = BitOperations.Swap(BitConverter.ToUInt64(cpukey, 0));
-            UInt64 part1 = BitOperations.Swap(BitConverter.ToUInt64(cpukey, 8));
-            if(BitOperations.CountSetBits(part0) + BitOperations.CountSetBits(part1 & 0xFFFFFFFFFF030000) != 53)
-                throw new X360UtilsException(X360UtilsException.X360UtilsErrors.InvalidKeyHamming);
+			VerifyCPUKeyHammingWeight(BitOperations.Swap(BitConverter.ToUInt64(cpukey, 0)), BitOperations.Swap(BitConverter.ToUInt64(cpukey, 8)));
         }
 
-        public static void VerifyCpuKey(string cpukey) {
+		private static void VerifyCPUKeyHammingWeight(UInt64 part0, UInt64 part1)
+		{
+			if (BitOperations.CountSetBits(part0) + BitOperations.CountSetBits(part1 & 0xFFFFFFFFFF030000) != 53)
+				throw new X360UtilsException(X360UtilsException.X360UtilsErrors.InvalidKeyHamming);
+		}
+
+		public static void VerifyCpuKey(string cpukey) {
             cpukey = cpukey.Trim();
             var tmp = StringUtils.HexToArray(cpukey);
             VerifyCpuKey(ref tmp);
@@ -76,14 +79,14 @@
         }
 
         public static void VerifyCpuKey(UInt64 part0, UInt64 part1) {
+            VerifyCPUKeyHammingWeight(part0, part1);
             var key = new byte[0x10];
-            var tmp = BitConverter.GetBytes(part0);
+            var tmp = BitConverter.GetBytes(BitOperations.Swap(part0));
             Buffer.BlockCopy(tmp, 0, key, 0, tmp.Length);
-            tmp = BitConverter.GetBytes(part1);
+            tmp = BitConverter.GetBytes(BitOperations.Swap(part1));
             Buffer.BlockCopy(tmp, 0, key, tmp.Length, tmp.Length);
-            VerifyCPUKeyHammingWeight(ref key);
             VerifyCPUKeyECD(ref key);
-   }
+		}
 
         public bool ReadKeyfile(string file, out string cpukey) {
             cpukey = "";


### PR DESCRIPTION
Fixes a bug where the GenerateRandomCPUKey routine would continue looping until the rng produced a result that had both the correct hamming weight, *and* a valid ECD, causing the routine to loop endlessly (the odds of randomly producing a valid ECD for that iteration's data is miniscule, at best).

The changes introduced here change the generator's loop to only require a valid hamming weight (usually satisfied in the first few attempts), and then calculate the ECD before returning the result.

To avoid superfluous code duplication, I split the verify routine into two smaller methods that could be reused in the Generate function.